### PR TITLE
nix: add a package and a home-manager module for declarative installs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788187754,
+        "narHash": "sha256-bu1QxmXKmPuvBLN7bHP355OV9Qo13x9WCiRDH62CqRM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5dfba6236110080a54247d6460bc2ff5dda939cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Haku Space -- Hyprland / Niri / MangoWM / Labwc dotfiles";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+
+  /*
+    A flake at the REPOSITORY ROOT, which is what `github:hakuimaku/hakuspace`
+    resolves to. nix/flake.nix stays exactly as it was, so anyone already using
+    `github:hakuimaku/hakuspace?dir=nix` keeps working -- but the plain URL
+    errors with "flake.nix does not exist" today, and a root flake is also the
+    only place a derivation can see src/ and assets/. A flake's source is the
+    directory containing it, so nix/package.nix reaching up to ../src would be
+    reaching outside the flake.
+  */
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      nixosModules = {
+        default = ./nix/hakuspace-config.nix;
+        hakuspace = ./nix/hakuspace-config.nix;
+      };
+
+      /*
+        The declarative half, for people who would rather not run install.sh.
+
+        hakuspace-config.nix installs PACKAGES and system services; it has
+        never placed a single dotfile. That is fine on a machine managed with
+        install.sh, and it is the one gap on a machine managed entirely by Nix,
+        where an imperatively-copied ~/.config is exactly the state a rebuild
+        cannot reproduce.
+
+        packages.hakuspace turns the tree into a derivation with its scripts'
+        dependencies wrapped onto PATH, and homeModules.hakuspace links it into
+        ~/.config. The config files are installed UNMODIFIED, so both routes
+        produce the same desktop and neither forks the configs from the other.
+      */
+      packages = forAllSystems (pkgs: rec {
+        default = hakuspace;
+        hakuspace = pkgs.callPackage ./nix/package.nix { };
+      });
+
+      homeModules = {
+        default = self.homeModules.hakuspace;
+        hakuspace =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ./nix/home-module.nix ];
+            programs.hakuspace.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.hakuspace;
+          };
+      };
+
+      # Older spelling; home-manager accepts either.
+      homeManagerModules = self.homeModules;
+    };
+}

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,0 +1,160 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.hakuspace;
+  share = "${cfg.package}/share/hakuspace";
+
+  /*
+    DIRECTORIES THE SCRIPTS WRITE INTO, and therefore the ones that must stay
+    real directories rather than becoming symlinks to the store.
+
+    This is the whole reason the module links config entries INDIVIDUALLY
+    instead of doing the obvious `xdg.configFile."waybar".source = ...`:
+
+      waybar_manager.sh:39   ln -sf "$target_dir/config"    "$WAYBAR_DIR/config"
+      waybar_manager.sh:40   ln -sf "$target_dir/style.css" "$WAYBAR_DIR/style.css"
+      rofi_theme_switcher.sh:35
+                             ln -sf "$USER_THEME_DIR/$t.rasi" "$CONFIG_DIR/$t.rasi"
+
+    Point ~/.config/waybar at a store path and layout switching fails with
+    "Read-only file system" -- the layouts are still there, but the switcher
+    can never select one. Linking the children leaves the parent a writable
+    directory that home-manager created, which is what those `ln -sf` calls
+    need.
+
+    Everything else is linked whole, because nothing writes into it: generated
+    theme output goes to ~/.local/state/haku_theme and user overrides to
+    ~/hakuspace-control, both outside ~/.config by design.
+  */
+  writableDirs = [ "waybar" "rofi" ];
+
+  # From passthru, never readDir on the package: see the note beside it in
+  # ./package.nix for why enumerating $out would make evaluation build.
+  inherit (cfg.package.passthru) configChildren scriptNames;
+
+  linkChildren = name: lib.listToAttrs (
+    map (child: {
+      name = "${name}/${child}";
+      value.source = "${share}/config/${name}/${child}";
+    }) configChildren.${name}
+  );
+
+  linkWhole = name: { ${name}.source = "${share}/config/${name}"; };
+
+  selected = lib.filter (n: builtins.elem n cfg.configNames) cfg.package.passthru.configNames;
+in
+{
+  options.programs.hakuspace = {
+    enable = lib.mkEnableOption "the Hakuspace desktop (Waybar, Rofi, SwayNC and its script suite)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The hakuspace package, as built by ./package.nix.";
+    };
+
+    compositor = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [ "hyprland" "niri" "mango" "labwc" ]);
+      default = null;
+      description = ''
+        Which window-manager config under src/wm to install, or null to install
+        none.
+
+        NULL IS A REAL CHOICE, not a placeholder. A configuration that already
+        manages its own compositor wants Hakuspace's bar, launcher and scripts
+        WITHOUT a second, complete compositor config competing for the same
+        file -- so the bar half and the window-manager half are separable.
+      '';
+    };
+
+    configNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = cfg.package.passthru.configNames;
+      defaultText = lib.literalExpression "every directory under src/common/config";
+      example = [ "waybar" "rofi" "swaync" ];
+      description = ''
+        Which entries under src/common/config to manage in ~/.config.
+
+        Narrow this where the host already owns a program: shipping the fish,
+        kitty or starship configs on a machine that configures those elsewhere
+        is a collision, and home-manager reports it as one rather than picking
+        a winner.
+      '';
+    };
+
+    controlDir = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Seed ~/hakuspace-control with the shipped defaults.
+
+          COPIED, NOT SYMLINKED, and that is the point of the directory: it is
+          where a user's own overrides live, so it has to be writable and has
+          to survive a rebuild that changes the package. Existing files are
+          never overwritten -- the same rule install.sh applies.
+        '';
+      };
+    };
+
+    extraScriptPath = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.playerctl ]";
+      description = ''
+        Extra packages on the scripts' PATH, for anything the wrapper in
+        ./package.nix does not already carry.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ] ++ cfg.extraScriptPath;
+
+    /*
+      Scripts at ~/.local/bin, where the configs and keybinds expect them.
+
+      The wrapped copies from the package, not the raw sources: the wrapper is
+      what puts rofi, cava, jq, hyprctl and the colorthief-capable python3 on
+      PATH, so a script works the same whether it was launched from a keybind,
+      from Waybar's on-click, or from a terminal with nothing installed.
+    */
+    home.file = lib.mkMerge [
+      (lib.listToAttrs (map (name: {
+        name = ".local/bin/${name}";
+        value.source = "${cfg.package}/bin/${name}";
+      }) scriptNames))
+
+      (lib.mkIf (cfg.compositor != null) {
+        # Whole-tree link: nothing writes into the WM config, and the custom
+        # entry point is ~/hakuspace-control/<wm>-custom.* which lives outside.
+        ".config/${if cfg.compositor == "hyprland" then "hypr" else cfg.compositor}".source =
+          "${share}/wm/${cfg.compositor}";
+      })
+    ];
+
+    xdg.configFile = lib.mkMerge (
+      map (n: if builtins.elem n writableDirs then linkChildren n else linkWhole n) selected
+    );
+
+    /*
+      The control directory, copied on activation.
+
+      writeBoundary first because this runs cp against $HOME: home-manager
+      requires anything touching the real home to be ordered after the point
+      where it has finished deciding what the generation contains.
+    */
+    home.activation.hakuspaceControl = lib.mkIf cfg.controlDir.enable (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        control="$HOME/hakuspace-control"
+        run mkdir -p "$control/waybar" "$control/rofi"
+        for f in ${share}/control/*; do
+          name="$(basename "$f")"
+          if [ ! -e "$control/$name" ]; then
+            run cp -r "$f" "$control/$name"
+            run chmod -R u+w "$control/$name"
+          fi
+        done
+      ''
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  python3,
+  # runtime, derived from what src/common/local/bin actually calls
+  bash,
+  coreutils,
+  findutils,
+  gnugrep,
+  gnused,
+  procps,
+  jq,
+  libnotify,
+  rofi,
+  waybar,
+  swaynotificationcenter,
+  cava,
+  cliphist,
+  wl-clipboard,
+  grim,
+  slurp,
+  imagemagick,
+  wlr-randr,
+  brightnessctl,
+  pulseaudio,
+  glib,
+  xdg-utils,
+  # optional -- null to leave the feature to fail gracefully at runtime
+  thunar ? null,
+  hyprland ? null,
+  hyprlock ? null,
+  hypridle ? null,
+  hyprpicker ? null,
+  hyprsunset ? null,
+  gammastep ? null,
+  mpvpaper ? null,
+  awww ? null,
+  wl-screenrec ? null,
+  kitty ? null,
+}:
+
+/*
+  Hakuspace as a PACKAGE rather than a directory of files to copy.
+
+  install.sh exists for distributions where that is the only option. On NixOS
+  the same tree can be a derivation: the scripts get their dependencies wrapped
+  onto PATH instead of relying on whatever the user happened to install, and
+  ~/.config entries become symlinks into the store, so a rebuild is the only
+  way the desktop changes.
+
+  WHAT IS DELIBERATELY NOT DONE HERE: the config files are installed BYTE FOR
+  BYTE. They reference $HOME/.local/bin/*.sh and $HOME/.local/state/haku_theme
+  throughout, and rewriting those to store paths would fork the configs from
+  upstream's and make every future update a merge conflict. The home-manager
+  module places the scripts at ~/.local/bin instead, so the references resolve
+  and the files stay identical to the ones install.sh writes.
+*/
+
+let
+  # colorthief drives the wallpaper accent extraction; pygobject3 is for the
+  # GTK-based desktop-icon and cava-underbar overlays.
+  pythonEnv = python3.withPackages (ps: with ps; [ colorthief pygobject3 ]);
+
+  runtimeDeps =
+    [
+      bash coreutils findutils gnugrep gnused procps jq libnotify
+      rofi waybar swaynotificationcenter cava cliphist wl-clipboard
+      grim slurp imagemagick wlr-randr brightnessctl pulseaudio glib
+      xdg-utils pythonEnv
+    ]
+    ++ lib.filter (d: d != null) [
+      hyprland hyprlock hypridle hyprpicker hyprsunset gammastep
+      mpvpaper awww wl-screenrec kitty thunar
+    ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "hakuspace";
+  version = "unstable";
+
+  src = lib.cleanSource ../.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/hakuspace $out/bin
+
+    # Configs, window-manager trees and the seed for ~/hakuspace-control,
+    # unmodified. The home-manager module decides which of these are linked.
+    cp -r src/common/config  $out/share/hakuspace/config
+    cp -r src/wm             $out/share/hakuspace/wm
+    cp -r assets/hakuspace-control $out/share/hakuspace/control
+    cp -r assets/browser     $out/share/hakuspace/browser
+
+    # Scripts keep their .sh/.py names: the configs and keybinds call them by
+    # basename under ~/.local/bin, so renaming any of them breaks the callers.
+    for f in src/common/local/bin/*; do
+      name=$(basename "$f")
+      install -Dm755 "$f" "$out/share/hakuspace/scripts/$name"
+    done
+
+    patchShebangs $out/share/hakuspace/scripts
+
+    for f in $out/share/hakuspace/scripts/*; do
+      name=$(basename "$f")
+      makeWrapper "$f" "$out/bin/$name" \
+        --prefix PATH : "${lib.makeBinPath runtimeDeps}" \
+        --prefix PATH : "$out/bin"
+    done
+
+    runHook postInstall
+  '';
+
+  /*
+    FILE LISTS COMPUTED FROM THE SOURCE TREE, not from $out.
+
+    The home-manager module has to enumerate what it is linking -- every
+    script, and every child of the directories that must stay writable. Doing
+    that with readDir on "${package}/share/..." would be import-from-derivation:
+    the package would have to be BUILT before the configuration could be
+    evaluated, so `nix eval` on a host, an editor's LSP, and `nix flake check`
+    would all trigger a build. These paths are plain source paths, so they are
+    readable during evaluation and cost nothing.
+  */
+  passthru =
+    let
+      configDir = ../src/common/config;
+      entries = builtins.readDir configDir;
+    in
+    {
+      configNames = builtins.attrNames entries;
+      configChildren = lib.mapAttrs (
+        name: type:
+        if type == "directory" then builtins.attrNames (builtins.readDir (configDir + "/${name}")) else [ ]
+      ) entries;
+      scriptNames = builtins.attrNames (builtins.readDir ../src/common/local/bin);
+    };
+
+  meta = {
+    description = "Hyprland / Niri / MangoWM / Labwc dotfiles with a shared Waybar, Rofi and SwayNC desktop";
+    homepage = "https://github.com/hakuimaku/hakuspace";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
hakuspace-config.nix installs packages and system services; it has never placed a dotfile. That is fine on a machine managed with install.sh, and it is the one gap on a machine managed entirely by Nix, where an imperatively-copied ~/.config is exactly the state a rebuild cannot reproduce.

  nix/package.nix      the tree as a derivation. Scripts get their
                       dependencies wrapped onto PATH -- rofi, cava, jq,
                       hyprctl and a python3 carrying colorthief and
                       pygobject3 -- so a script behaves the same launched
                       from a keybind, from Waybar's on-click, or from a
                       terminal with nothing installed.
  nix/home-module.nix  programs.hakuspace.*, linking that package into
                       ~/.config, ~/.local/bin and ~/hakuspace-control.
  flake.nix            at the repository ROOT.

CONFIG FILES ARE INSTALLED BYTE FOR BYTE. They reference $HOME/.local/bin/*.sh and $HOME/.local/state/haku_theme throughout, and rewriting those to store paths would fork them from the ones install.sh writes and make every future update a merge conflict. The module places the scripts at ~/.local/bin instead, so the references resolve unchanged and both installation routes produce the same desktop.

WAYBAR AND ROFI ARE LINKED CHILD BY CHILD, not as whole directories, and this is the one non-obvious thing in the module:

    waybar_manager.sh:39   ln -sf "$target_dir/config"    "$WAYBAR_DIR/config"
    rofi_theme_switcher.sh:35
                           ln -sf "$USER_THEME_DIR/$t.rasi" "$CONFIG_DIR/$t.rasi"

Both write INTO their config directory. Pointing ~/.config/waybar at a store path leaves every layout present but makes switching fail on a read-only filesystem. Linking the children leaves the parent a writable directory, which is what those calls need. Everything else is linked whole, because nothing writes into it -- generated themes go to ~/.local/state/haku_theme and overrides to ~/hakuspace-control, both outside ~/.config by design.

~/hakuspace-control is COPIED, not symlinked, and existing files are never overwritten -- the same rule install.sh applies, for the same reason: it is where a user's own overrides live.

The file lists the module needs are computed from the source tree via passthru, never with readDir on the built package: the latter is import-from-derivation, which would make `nix eval`, an editor's LSP and `nix flake check` all trigger a build before they could report anything.

nix/flake.nix is left exactly as it was, so anyone using `github:hakuimaku/hakuspace?dir=nix` is unaffected. The new root flake is additive: `github:hakuimaku/hakuspace` currently errors with "flake.nix does not exist", and a flake's source is the directory containing it, so a derivation under nix/ could not see src/ or assets/ at all.

Verified by evaluating a home-manager configuration against the module: waybar's nine layouts plus module/ and dockbar/ and rofi's four themes link individually, cava/fastfetch/swaync link whole, 37 scripts land in ~/.local/bin, and the hyprland tree lands at ~/.config/hypr.